### PR TITLE
Warning fixes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,13 +13,13 @@ use clap::{App, Arg};
 
 use midir::{Ignore, MidiInput, MidiInputConnection};
 
-mod midi;
+pub mod midi;
 use midi::{MidiMessage, MidiEvent, MidiNote};
 
-mod appstate;
+pub mod appstate;
 use appstate::AppState;
 
-mod notemappings;
+pub mod notemappings;
 use notemappings::{Event, KbdKey, NoteMapping, NoteMappings};
 
 #[cfg(feature = "debug")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,7 +201,7 @@ fn generate_old_mappings(mappings: &mut NoteMappings) {
     }
 }
 
-fn run(midi_name: Option<String>) -> Result<(), Box<Error>> {
+fn run(midi_name: Option<String>) -> Result<(), Box<dyn Error>> {
     let mut midi_ports: HashMap<String, MidiInputConnection<()>> = HashMap::new();
     let app_state = AppState::new();
 
@@ -268,7 +268,7 @@ fn run(midi_name: Option<String>) -> Result<(), Box<Error>> {
     }
 }
 
-fn list_devices() -> Result<(), Box<Error>> {
+fn list_devices() -> Result<(), Box<dyn Error>> {
     let mut midi_in = MidiInput::new("perform")?;
     midi_in.ignore(Ignore::None);
 

--- a/src/notemappings.rs
+++ b/src/notemappings.rs
@@ -17,12 +17,8 @@ pub enum KbdKey {
     Backspace,
     /// escape key (esc)
     Escape,
-    /// super key on linux (command key on macOS, windows key on Windows)
-    Super,
-    /// command key on macOS (super key on Linux, windows key on Windows)
-    Command,
-    /// windows key on Windows (super key on Linux, command key on macOS)
-    Windows,
+    /// super key on linux command key on macOS, windows key on Windows
+    Meta,
     /// shift key
     Shift,
     /// caps lock key
@@ -85,9 +81,7 @@ impl KbdKey {
             KbdKey::Space => Key::Space,
             KbdKey::Backspace => Key::Backspace,
             KbdKey::Escape => Key::Escape,
-            KbdKey::Super => Key::Super,
-            KbdKey::Command => Key::Command,
-            KbdKey::Windows => Key::Windows,
+            KbdKey::Meta => Key::Meta,
             KbdKey::Shift => Key::Shift,
             KbdKey::CapsLock => Key::CapsLock,
             KbdKey::Alt => Key::Alt,

--- a/src/notemappings.rs
+++ b/src/notemappings.rs
@@ -215,7 +215,7 @@ impl NoteMappings {
 
     pub fn import(&mut self, filename: &str) -> Result<()> {
         let f = File::open(filename)?;
-        let mut buf_reader = BufReader::new(f);
+        let buf_reader = BufReader::new(f);
         for line in buf_reader.lines() {
             let l = line.unwrap();
             let fields: Vec<&str> = l.split(" ").collect();

--- a/src/notemappings.rs
+++ b/src/notemappings.rs
@@ -224,9 +224,9 @@ impl NoteMappings {
                 continue;
             }
             let note_txt = fields[0];
-            let channel_txt = fields[1];
-            let keydown_txt = fields[2];
-            let keyup_txt = fields[3];
+            let _channel_txt = fields[1];
+            let _keydown_txt = fields[2];
+            let _keyup_txt = fields[3];
             let note = MidiNote::new_from_text(&note_txt);
             println!("Got line: {}  Note: {:?}", l, note);
         }


### PR DESCRIPTION
this PR fixes all warnings when compiling in rust 1.42, without introducing new ones.