### PR TITLE
Fix: Properly send key-up events when releasing keys

### DIFF
--- a/src/appstate.rs
+++ b/src/appstate.rs
@@ -34,7 +34,7 @@ impl KeyGen {
     /// Returns `true` if an event was sent.
     pub fn key_up(&mut self, key: &KbdKey) -> bool {
         if let Some(val) = self.key_state.get(key) {
-            if *val {
+            if !*val {
                 return false;
             }
         }


### PR DESCRIPTION
Hi! I noticed key up events weren't getting sent because we were skipping sending the key-up event if the note is pressed in the key_state HashMap. This should fix the bug 🙂